### PR TITLE
CVE-2024-6387 :: HOTFIX for openSSH vulnerability

### DIFF
--- a/deploy/compute-engine.tf
+++ b/deploy/compute-engine.tf
@@ -18,7 +18,7 @@ resource "google_compute_instance" "nestjs" {
     device_name = "nestjs-boot-disk"
 
     initialize_params {
-      image = "projects/cos-cloud/global/images/cos-stable-113-18244-1-61"
+      image = "projects/cos-cloud/global/images/cos-113-18244-85-49"
       size  = 10
       type  = "pd-balanced"
     }


### PR DESCRIPTION
# Description
Fix for vulnerability shared by google on 2024-07-02
https://cloud.google.com/compute/docs/security-bulletins?&_gl=1*1yi7yav*_ga*Nzg3NzM3ODYyLjE3MTQ1NzA3Mjc.*_ga_WH2QY8WWF5*MTcxOTg3MjE5NC42NC4wLjE3MTk4NzIxOTQuNjAuMC4w&_ga=2.24975420.-787737862.1714570727&_gac=1.28583246.1719680779.CjwKCAjw4f6zBhBVEiwATEHFVhVXs98tDC1ITpokXX2B0Fyyrcd7tUfsvrPS5vJH9A0Oc3FJxYdgxhoCm0gQAvD_BwE#gcp-2024-040 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation (only changing docs)
- [ ] Refactoring (no new features added) 

# How Has This Been Tested?
 
..



